### PR TITLE
Dockerfileの生成時のバグ修正

### DIFF
--- a/aws/create_dockerfile.sh
+++ b/aws/create_dockerfile.sh
@@ -5,7 +5,7 @@ cat << 'EOF' >> backend/Dockerfile
 
 
 # Setup AWS CLI
-COPY aws/awscli_setup.sh /tmp
+COPY awscli_setup.sh /tmp
 RUN chmod +x /tmp/awscli_setup.sh && /tmp/awscli_setup.sh
 ARG XCKAN_SITEMAP_URL
 ARG XCKAN_SITEMAP_DIR

--- a/aws/create_dockerfile.sh
+++ b/aws/create_dockerfile.sh
@@ -1,7 +1,7 @@
 #/bin/sh
 
-cp backend/Dockerfile aws/Dockerfile
-cat << 'EOF' >> aws/Dockerfile
+cp -p aws/awscli_setup.sh backend/awscli_setup.sh
+cat << 'EOF' >> backend/Dockerfile
 
 
 # Setup AWS CLI

--- a/aws/leader_backend_buildspec.yml
+++ b/aws/leader_backend_buildspec.yml
@@ -7,13 +7,13 @@ env:
 phases:
   pre_build:
     commands:
-      - aws/create_dockerfile.sh
+      - chmod +x aws/create_dockerfile.sh && aws/create_dockerfile.sh
       - $(aws ecr get-login --region $REGION --no-include-email)
       - AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query 'Account' --output text)
       - IMAGE_TAG=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)
   build:
     commands: >-
-      docker build -f aws/Dockerfile .
+      docker build ./backend
       -t ${ECR_URL}:leader-${IMAGE_TAG}
       --build-arg XCKAN_BACKEND_SRC=$XCKAN_BACKEND_SRC
       --build-arg DJANGO_SUPERUSER_USERNAME=$DJANGO_SUPERUSER_USERNAME


### PR DESCRIPTION
# What
[awsリーダータスク用dockerfileをshellから生成](https://github.com/tadokoroshoma/xckan-docker/commit/e27e3a774ef14650da8ce5e45267e20c6d8a1822)
Dockerfileの生成時のCIエラーを解消